### PR TITLE
Fix for highlight issues

### DIFF
--- a/AceJump.tmLanguage
+++ b/AceJump.tmLanguage
@@ -1,0 +1,18 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>AceJump</string>
+    <key>patterns</key>
+    <array>
+        <dict>
+            <key>match</key>
+            <string>(.*)</string>
+            <key>name</key>
+            <string>text.ace_jump</string>
+        </dict>
+    </array>
+    <key>scopeName</key>
+    <string>comment</string>
+</dict>
+</plist>

--- a/ace_jump.py
+++ b/ace_jump.py
@@ -137,6 +137,8 @@ class AddAceJumpLabelsCommand(sublime_plugin.TextCommand):
     def run(self, edit, char):
         global next_search, last_index
 
+        view_hints = []
+
         visible_region = self.view.visible_region()
         next_search = next_search if next_search else visible_region.begin()
         last_search = visible_region.end()
@@ -151,7 +153,7 @@ class AddAceJumpLabelsCommand(sublime_plugin.TextCommand):
             last_index += 1
 
             hint = sublime.Region(word.begin(), word.begin() + 1)
-            hints.append(hint)
+            view_hints.append(hint)
 
             self.view.replace(edit, hint, label)
 
@@ -160,7 +162,10 @@ class AddAceJumpLabelsCommand(sublime_plugin.TextCommand):
         if last_index < len(LABELS):
             next_search = False
 
-        self.view.add_regions("ace_jump_hints", hints, "invalid")
+        self.view.add_regions("ace_jump_hints", view_hints, "invalid")
+
+        for hint in view_hints:
+            hints.append(hint)
 
 class RemoveAceJumpLabelsCommand(sublime_plugin.TextCommand):
     def run(self, edit):

--- a/ace_jump.py
+++ b/ace_jump.py
@@ -84,6 +84,7 @@ class AceJumpCommand(sublime_plugin.WindowCommand):
     def jump(self):
         global next_search
 
+        next_search = False
         last_breakpoint = 0
 
         for breakpoint in self.breakpoints:
@@ -105,8 +106,6 @@ class AceJumpCommand(sublime_plugin.WindowCommand):
 
         self.window.focus_view(target_view)
         target_view.run_command("perform_ace_jump", {"target": target_region})
-
-        next_search = False
 
     def view_for_index(self, index):
         for breakpoint in self.breakpoints:

--- a/ace_jump.py
+++ b/ace_jump.py
@@ -16,9 +16,13 @@ class AceJumpCommand(sublime_plugin.WindowCommand):
         self.all_views = []
         self.changed_views = []
         self.breakpoints = []
+        self.syntax = []
 
         for group in range(self.window.num_groups()):
             self.all_views.append(self.window.active_view_in_group(group))
+
+        for view in self.all_views:
+            self.syntax.append(view.settings().get('syntax'))
 
         self.window.show_input_panel(
             self.prompt(),
@@ -64,6 +68,9 @@ class AceJumpCommand(sublime_plugin.WindowCommand):
         self.views = self.all_views[:] if len(self.views) == 0 else self.views
         self.changed_views = []
 
+        for view in self.all_views:
+            view.set_syntax_file('Packages/AceJump/AceJump.tmLanguage')
+
         for view in self.views[:]:
             view.run_command("add_ace_jump_labels", {"char": self.char})
             self.breakpoints.append(last_index)
@@ -84,6 +91,9 @@ class AceJumpCommand(sublime_plugin.WindowCommand):
                 view = self.changed_views[self.view_for_index(breakpoint - 1)]
                 view.run_command("remove_ace_jump_labels")
                 last_breakpoint = breakpoint
+
+        for i in range(len(self.all_views)):
+            self.all_views[i].set_syntax_file(self.syntax[i])
 
         target_index = LABELS.find(self.target)
 


### PR DESCRIPTION
This pull request fixes a number of bugs with the highlights and improves the readability of the labels.
- Fixed the bug where highlights from one file would be dragged over to all subsequent ones when working with multiple panes
- Fixed the bug where some occurences of a character would be skipped after canceling the command earlier.
- Syntax highlighting is disabled while the labels are being shown to improve their readability
