### PR TITLE
current_buffer_only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ You can then override the bindings for any of the following commands:
 - ```ace_jump_select```
 - ```ace_jump_add_cursor```
 
+The commands accept an optional Boolean `current_buffer_only` argument. When present and set to `true`, AceJump only performs on the currently edited buffer.
+
 ### Labels
 
 Go to ```Preferences > Package Settings > AceJump > Settings - User```,

--- a/ace_jump.py
+++ b/ace_jump.py
@@ -9,12 +9,15 @@ next_search = False
 
 mode = 0
 
-def get_active_views(window):
+def get_active_views(window, current_buffer_only):
     """Returns all currently visible views"""
 
     views = []
-    for group in range(window.num_groups()):
-        views.append(window.active_view_in_group(group))
+    if current_buffer_only:
+        views.append(window.active_view())
+    else:
+        for group in range(window.num_groups()):
+            views.append(window.active_view_in_group(group))
     return views
 
 def set_views_setting(views, setting, values):
@@ -75,14 +78,14 @@ def clear_views_sel(views):
 class AceJumpCommand(sublime_plugin.WindowCommand):
     """Base command class for AceJump plugin"""
 
-    def run(self):
+    def run(self, current_buffer_only = False):
         self.char = ""
         self.target = ""
         self.views = []
         self.changed_views = []
         self.breakpoints = []
 
-        self.all_views = get_active_views(self.window)
+        self.all_views = get_active_views(self.window, current_buffer_only)
         self.syntax = get_views_setting(self.all_views, "syntax")
         self.sel = get_views_sel(self.all_views)
 


### PR DESCRIPTION
Allow a `current_buffer_only` arg, which would limit AceJump to the currently editing buffer only.

Usage:

```
{
  "keys": ["ctrl+shift+;"],
  "command": "ace_jump_word",
  "args": {
    "current_buffer_only": true,
  }
}
```
