### PR TITLE
Fix python escaping < and > while view.find() does not need it

### DIFF
--- a/ace_jump.py
+++ b/ace_jump.py
@@ -134,7 +134,11 @@ class AceJumpCommand(sublime_plugin.WindowCommand):
 
         if len(command) == 1:
             self.char = command
-            self.add_labels(self.regex().format(re.escape(self.char)))
+            if self.char == "<" or self.char == ">":
+                # re.escape escapes these 2 characters but it isn't needed for view.find()
+                self.add_labels(self.regex().format(self.char))
+            else:
+                self.add_labels(self.regex().format(re.escape(self.char)))
             return
 
         if len(command) == 2:


### PR DESCRIPTION
Jumping to < and > in character mode right now doesn't work because re.escape() escape them to '\<' and '\>' but sublime uses '<' and '>'.