### PR TITLE
Added double character labels support

### DIFF
--- a/AceJump.sublime-settings
+++ b/AceJump.sublime-settings
@@ -1,6 +1,6 @@
 {
     // Characters to be used as labels in order they'll appear
-    "labels": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "labels": "fjdkslagheiworutyqpcvmxzbnFJDKSLAGHEIWORUTYQPCVMXZBN",
 
     // Syntax highlighting scope for the labels
     "labels_scope": "invalid",

--- a/AceJump.sublime-settings
+++ b/AceJump.sublime-settings
@@ -8,6 +8,9 @@
     // Enable double character label, eg. aa AA aB ...
     "double_char_label": false,
 
+    // Jump to boundary if the char is at the end of a word insteadly
+    "jump_to_boundary": true,
+
     // Toggles case sensitive search in word and character modes.
     "search_case_sensitivity": true,
 

--- a/AceJump.sublime-settings
+++ b/AceJump.sublime-settings
@@ -5,6 +5,9 @@
     // Syntax highlighting scope for the labels
     "labels_scope": "invalid",
 
+    // Enable double character label, eg. aa AA aB ...
+    "double_char_label": false,
+
     // Toggles case sensitive search in word and character modes.
     "search_case_sensitivity": true,
 

--- a/ace_jump.py
+++ b/ace_jump.py
@@ -373,7 +373,7 @@ class AceJumpWithinLineCommand(AceJumpCommand):
         return " "
 
     def regex(self):
-        return r'(?<=[^\w])\w|\w(?=[^\w])'
+        return r'\b\w|\w\b|(?<=_)\w|\w(?=_)'
 
     def after_jump(self, view):
         global mode

--- a/ace_jump.py
+++ b/ace_jump.py
@@ -373,7 +373,7 @@ class AceJumpWithinLineCommand(AceJumpCommand):
         return " "
 
     def regex(self):
-        return r'\b\w'
+        return r'(?<=[^\w])\w|\w(?=[^\w])'
 
     def after_jump(self, view):
         global mode

--- a/ace_jump.py
+++ b/ace_jump.py
@@ -82,15 +82,20 @@ def get_views_sel(views):
         selections.append(view.sel())
     return selections
     
-def index_to_cmp(label):
-    """Custom key funtion for list's sort method, returns integer number based on label index
-    of the default label set
-    """
-    global ace_jump_labels
-    index = ace_jump_labels.find(label[0]) + ace_jump_labels.find(label[1])
-    if label[0] == label[1]:
-        index -= 100
-    return index
+def sort_double_char_labels(labels):
+    """Sort double char labels based on the order of repeated, lower and other labels"""
+    repeated_char_labels = [label for label in labels if label[0] == label[1]]
+
+    lower_char_labels = [label for label in labels
+                         if label[0].islower() and label[1].islower()
+                         and label not in repeated_char_labels]
+
+    other_labels = [label for label in labels
+                    if label not in repeated_char_labels and label not in lower_char_labels]
+
+    labels = repeated_char_labels + lower_char_labels + other_labels
+
+    return labels
 
 class AceJumpCommand(sublime_plugin.WindowCommand):
     """Base command class for AceJump plugin"""
@@ -453,7 +458,7 @@ class AddAceJumpLabelsCommand(sublime_plugin.TextCommand):
 
         if double_char_label and len(regions) > len(labels):
             labels = [char_a + char_b for char_a in labels for char_b in labels]
-            labels.sort(key=index_to_cmp)
+            labels = sort_double_char_labels(labels)
             for i, region in enumerate(regions):
                 regions[i] = sublime.Region(region.a, region.b + 1)
 

--- a/ace_jump.py
+++ b/ace_jump.py
@@ -1,6 +1,5 @@
 import sublime, sublime_plugin
 import re, itertools
-from functools import partial
 
 last_index = 0
 hints = []

--- a/ace_jump.py
+++ b/ace_jump.py
@@ -306,7 +306,7 @@ class AceJumpWordCommand(AceJumpCommand):
         return ""
 
     def regex(self):
-        return r'\b{}'
+        return r'\b{0}|{0}\b|(?<=_){0}|{0}(?=_)'
 
     def after_jump(self, view):
         global mode


### PR DESCRIPTION
Added double character labels support. and an option ("double_char_label") to toggle this feature. 
The number of double-char labels is 2704 (26*2**2) by default, which is much more than the one  of single-char labels. It is sufficient to cover full view of text in most cases, so that it is more intuitive to label the character under focus of your eyes at the first time instead of pressing "Enter" key several times to reach the character you want to go for. 

screenshots attached to compare:

"double_char_label": true
![double_char_label](https://user-images.githubusercontent.com/2269311/30854275-d692941e-a276-11e7-8994-83e9f15019e3.png)

"double_char_label": false (default)
![single_char_label](https://user-images.githubusercontent.com/2269311/30854274-d691a824-a276-11e7-968e-b92b5eef72ab.png)
