### PR TITLE
Cycling back with shift+enter

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -26,5 +26,9 @@
     {
         "keys": ["alt+."],
         "command": "ace_jump_after"
+    },
+    {
+        "keys": ["shift+enter"],
+        "command": "ace_jump_previous"
     }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -26,5 +26,9 @@
     {
         "keys": ["ctrl+."],
         "command": "ace_jump_after"
+    },
+    {
+        "keys": ["shift+enter"],
+        "command": "ace_jump_previous"
     }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -26,5 +26,9 @@
     {
         "keys": ["alt+."],
         "command": "ace_jump_after"
+    },
+    {
+        "keys": ["shift+enter"],
+        "command": "ace_jump_previous"
     }
 ]

--- a/ace_jump.py
+++ b/ace_jump.py
@@ -84,6 +84,7 @@ class AceJumpCommand(sublime_plugin.WindowCommand):
         ace_jump_active = True
 
         self.char = ""
+        self.prev= ""    #OWN EDIT
         self.target = ""
         self.views = []
         self.changed_views = []
@@ -425,6 +426,22 @@ class AddAceJumpLabelsCommand(sublime_plugin.TextCommand):
             'visible_region': lambda view : view.visible_region(),
             'current_line': lambda view : view.line(view.sel()[0]),
         }.get(region_type)(self.view)
+
+class AceJumpPrevCommand(AceJumpCommand):  #OWN EDIT
+    """Specialized command for cycling back to previous highlight"""
+
+    def init_value(self):
+        return ""
+
+    def regex(self):
+        return r'\b{}'
+
+    def after_jump(self, view):
+        global mode
+
+        if mode == 3:
+            view.run_command("move", {"by": "word_ends", "forward": True})
+            mode = 0
 
 class RemoveAceJumpLabelsCommand(sublime_plugin.TextCommand):
     """Command for removing labels from the views"""


### PR DESCRIPTION
Added the commands "shift+enter" in the key maps, and made a class to handle jumping to previous highlight. More changes need to be made for the feature to work completely.